### PR TITLE
Investigate and fix GitHub issue #1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,4 +13,7 @@ DATABASE_URL=sqlite:///./investing_assistant.db
 CHROMA_PERSIST_DIRECTORY=./chroma_db
 
 # Frontend Configuration
+# Note: For local development, create frontend/.env.local with:
+# NEXT_PUBLIC_API_URL=http://localhost:8200
+# For Docker deployments, this is set via docker-compose.yml build args
 NEXT_PUBLIC_API_URL=http://localhost:8200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,13 +24,15 @@ services:
     restart: unless-stopped
 
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      args:
+        NEXT_PUBLIC_API_URL: http://localhost:8200
     container_name: investing_assistant_frontend
     ports:
       - "3200:3200"
     environment:
       - NODE_ENV=production
-      - NEXT_PUBLIC_API_URL=http://localhost:8200
     depends_on:
       - backend
     restart: unless-stopped

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,11 @@ RUN npm install
 # Copy application code
 COPY . .
 
-# Build application
+# Accept build argument for API URL
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+
+# Build application (with environment variable available)
 RUN npm run build
 
 # Expose port

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,4 +1,13 @@
 export async function api(path: string, options: RequestInit = {}) {
+  // Validate that API URL is configured
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!apiUrl) {
+    throw new Error(
+      "API URL is not configured. Please ensure NEXT_PUBLIC_API_URL is set in your environment. " +
+      "For local development, create frontend/.env.local with NEXT_PUBLIC_API_URL=http://localhost:8200"
+    );
+  }
+
   const token =
     typeof window !== "undefined" ? localStorage.getItem("token") : null;
 
@@ -18,7 +27,7 @@ export async function api(path: string, options: RequestInit = {}) {
   // Exclude headers from options spread to prevent overwriting our headers
   const { headers: _ignored, ...restOptions } = options;
 
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}${path}`, {
+  const res = await fetch(`${apiUrl}${path}`, {
     ...restOptions,
     headers,
   });


### PR DESCRIPTION
…ration

Fixes #12

## Problem
Chart data was not showing up for any tickers because the NEXT_PUBLIC_API_URL environment variable was not available during the Next.js build process. This caused all API calls to use "undefined" as the base URL, resulting in failed requests and blank charts.

## Root Cause
Next.js embeds NEXT_PUBLIC_* environment variables at build time, not runtime. The previous Dockerfile ran 'npm run build' without this variable set, and docker-compose.yml only set it as a runtime environment variable, which was too late.

## Solution
1. **Frontend Dockerfile**: Added ARG and ENV for NEXT_PUBLIC_API_URL to make it available during the build process
2. **docker-compose.yml**: Updated frontend service to pass NEXT_PUBLIC_API_URL as a build argument
3. **frontend/.env.local**: Created for local development (auto-ignored by git)
4. **frontend/lib/api.ts**: Added validation and helpful error message when API URL is not configured
5. **.env.example**: Updated documentation about frontend environment setup

## Testing
For Docker deployments:
- Run: docker-compose up -d --build
- The frontend will now have NEXT_PUBLIC_API_URL properly embedded at build time

For local development:
- The .env.local file provides the API URL
- Run: cd frontend && npm run dev
- Charts will now load data correctly

## Impact
- Fixes chart data display for all tickers
- Improves developer experience with better error messages
- Documents environment setup requirements